### PR TITLE
Debug page navigation issue

### DIFF
--- a/src/main/webapp/app/config/icon-loader.ts
+++ b/src/main/webapp/app/config/icon-loader.ts
@@ -42,6 +42,7 @@ import {
   faUsers,
   faUsersCog,
   faWrench,
+  faXmark,
 } from '@fortawesome/free-solid-svg-icons';
 
 import { library } from '@fortawesome/fontawesome-svg-core';
@@ -91,5 +92,6 @@ export const loadIcons = () => {
     faUsers,
     faUsersCog,
     faWrench,
+    faXmark,
   );
 };

--- a/src/main/webapp/app/modules/administration/authorization/authority/manage-permissions-dialog.tsx
+++ b/src/main/webapp/app/modules/administration/authorization/authority/manage-permissions-dialog.tsx
@@ -198,7 +198,7 @@ export const ManagePermissionsDialog: React.FC<ManagePermissionsDialogProps> = (
       </ModalBody>
       <ModalFooter>
         <Button color="secondary" onClick={onClose}>
-          <FontAwesomeIcon icon="times" />
+          <FontAwesomeIcon icon="xmark" />
           &nbsp;
           <Translate contentKey="entity.action.close">Close</Translate>
         </Button>


### PR DESCRIPTION
…wesome 6

- Agregar faXmark al icon-loader.ts
- Actualizar manage-permissions-dialog.tsx para usar 'xmark' en lugar de 'times'
- Soluciona error: "Could not find icon {prefix: 'fas', iconName: 'times'}"

En Font Awesome 6, el ícono 'times' fue renombrado a 'xmark'.